### PR TITLE
feat(claude): support CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/src/claude/claude-config.js
+++ b/src/claude/claude-config.js
@@ -1,0 +1,11 @@
+import path from 'path';
+import os from 'os';
+
+/**
+ * Get the Claude Code configuration directory.
+ * Respects CLAUDE_CONFIG_DIR environment variable, falls back to ~/.claude
+ * @returns {string} The Claude configuration directory path
+ */
+export function getClaudeConfigDir() {
+  return process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+}

--- a/src/claude/hook-setup.js
+++ b/src/claude/hook-setup.js
@@ -16,7 +16,8 @@ class HookSetup {
 
   // Use global Claude settings file only
   getSettingsPath() {
-    return path.join(os.homedir(), '.claude', 'settings.json');
+    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+    return path.join(claudeConfigDir, 'settings.json');
   }
 
   loadSettings(settingsPath) {

--- a/src/claude/hook-setup.js
+++ b/src/claude/hook-setup.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import Logger from '../logger.js';
+import { getClaudeConfigDir } from './claude-config.js';
 
 class HookSetup {
   constructor() {
@@ -16,8 +16,7 @@ class HookSetup {
 
   // Use global Claude settings file only
   getSettingsPath() {
-    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-    return path.join(claudeConfigDir, 'settings.json');
+    return path.join(getClaudeConfigDir(), 'settings.json');
   }
 
   loadSettings(settingsPath) {

--- a/src/claude/slash-command-setup.js
+++ b/src/claude/slash-command-setup.js
@@ -10,7 +10,8 @@ class SlashCommandSetup {
 
   // Use global Claude commands directory only
   getCommandsPath() {
-    return path.join(os.homedir(), '.claude', 'commands');
+    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+    return path.join(claudeConfigDir, 'commands');
   }
 
   // Create /hey slash command for toggling notifications

--- a/src/claude/slash-command-setup.js
+++ b/src/claude/slash-command-setup.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import Logger from '../logger.js';
+import { getClaudeConfigDir } from './claude-config.js';
 
 class SlashCommandSetup {
   constructor() {
@@ -10,8 +10,7 @@ class SlashCommandSetup {
 
   // Use global Claude commands directory only
   getCommandsPath() {
-    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-    return path.join(claudeConfigDir, 'commands');
+    return path.join(getClaudeConfigDir(), 'commands');
   }
 
   // Create /hey slash command for toggling notifications


### PR DESCRIPTION
## Summary

Add support for the `CLAUDE_CONFIG_DIR` environment variable to allow users to customize the location of Claude Code configuration files. This ensures HeyAgent respects user's custom Claude Code configuration directory when set, while maintaining backward compatibility with the default `~/.claude` location.

## What Changed

### Commit 1: feat(claude): support CLAUDE_CONFIG_DIR environment variable
- **`src/claude/hook-setup.js`**: Updated `getSettingsPath()` method to check `CLAUDE_CONFIG_DIR` environment variable before falling back to default `~/.claude/settings.json`
- **`src/claude/slash-command-setup.js`**: Updated `getCommandsPath()` method to check `CLAUDE_CONFIG_DIR` environment variable before falling back to default `~/.claude/commands`

### Commit 2: refactor(claude): extract getClaudeConfigDir to shared utility
- **`src/claude/claude-config.js`**: Created new utility module with `getClaudeConfigDir()` function to provide single source of truth for Claude config directory resolution
- **`src/claude/hook-setup.js`**: Refactored to use shared utility function
- **`src/claude/slash-command-setup.js`**: Refactored to use shared utility function
- Removed code duplication and unused `os` imports

## Why

Currently, HeyAgent hardcoded the Claude Code configuration directory to `~/.claude`. However, Claude Code supports the `CLAUDE_CONFIG_DIR` environment variable to allow users to customize this location (e.g., `~/.config/claude`). Without this change, HeyAgent would not work correctly when users have set a custom Claude configuration directory.

The refactoring into a shared utility function eliminates code duplication, follows the DRY (Don't Repeat Yourself) principle, and makes the codebase more maintainable.

## Implementation Details

The implementation follows a simple fallback pattern in the shared utility:
```javascript
export function getClaudeConfigDir() {
  return process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
}
```

This ensures:
1. If `CLAUDE_CONFIG_DIR` is set, use that directory
2. Otherwise, fall back to the default `~/.claude` directory
3. Single source of truth for this logic across the codebase

## Testing

- ✅ Verified fallback logic works correctly when `CLAUDE_CONFIG_DIR` is not set
- ✅ Verified environment variable is properly read when set
- ✅ Passed ESLint and Prettier checks
- ✅ No changes to existing functionality when using default configuration
- ✅ No code duplication - shared utility function used consistently

## Related Issues

This addresses the design limitation where HeyAgent did not consider both default `.claude` and custom `CLAUDE_CONFIG_DIR` configurations.

## Notes

- No changes needed for Codex wrapper as it passes `process.env` directly to the spawned process
- Backward compatible - existing installations using default `~/.claude` will continue to work without any changes
- Improved code quality through refactoring and elimination of duplication