### PR TITLE
Write notification event file for external tool correlation

### DIFF
--- a/src/agent/agent-wrapper.js
+++ b/src/agent/agent-wrapper.js
@@ -1,7 +1,9 @@
 import pty from '@lydell/node-pty';
 import process from 'process';
+import path from 'path';
 import Logger from '../logger.js';
 import NotificationService from '../notification.js';
+import { writeNotificationEvent } from '../notification-event.js';
 
 function createNotificationMessages(agentName) {
   const capitalizedName = agentName.charAt(0).toUpperCase() + agentName.slice(1);
@@ -38,6 +40,7 @@ export default class AgentWrapper {
       if (this.appState === 'working') {
         this.appState = 'notified';
         try {
+          writeNotificationEvent({ project: path.basename(process.cwd()), message: this.notifications.message });
           await this.notificationService.send(this.notifications.title, this.notifications.message);
         } catch (err) {
           this.logger.error(`Notification error: ${err.message || err}`);

--- a/src/claude/hook.js
+++ b/src/claude/hook.js
@@ -1,9 +1,11 @@
 import process from 'process';
+import path from 'path';
 import Logger from '../logger.js';
 import { NOTIFY_TITLE_CLAUDE, NOTIFY_MSG_CLAUDE_DONE } from '../constants.js';
 
 import Config from '../config.js';
 import NotificationService from '../notification.js';
+import { writeNotificationEvent } from '../notification-event.js';
 
 class HookHandler {
   constructor() {
@@ -32,16 +34,25 @@ class HookHandler {
 
     const eventType = hookData.hook_event_name;
     const message = hookData.message;
+    const cwd = hookData.cwd || '';
+    const project = cwd ? path.basename(cwd) : 'unknown';
+    const sessionId = hookData.session_id || 'unknown';
+    const shortSession = sessionId.slice(0, 8);
 
     const notificationService = this.getNotificationService();
 
+    let body;
     if (eventType === 'Stop') {
-      await notificationService.send(NOTIFY_TITLE_CLAUDE, NOTIFY_MSG_CLAUDE_DONE);
+      body = NOTIFY_MSG_CLAUDE_DONE;
     } else if (eventType === 'Notification') {
-      await notificationService.send(NOTIFY_TITLE_CLAUDE, message);
+      body = message;
     } else {
       this.logger.info(`Unknown event type: ${eventType}`);
+      return;
     }
+
+    writeNotificationEvent({ project, sessionId: shortSession, message: body });
+    await notificationService.send(NOTIFY_TITLE_CLAUDE, body, project);
   }
 }
 

--- a/src/codex/codex-wrapper.js
+++ b/src/codex/codex-wrapper.js
@@ -1,7 +1,9 @@
 import pty from '@lydell/node-pty';
 import process from 'process';
+import path from 'path';
 import Logger from '../logger.js';
 import NotificationService from '../notification.js';
+import { writeNotificationEvent } from '../notification-event.js';
 import { NOTIFY_TITLE_CODEX, NOTIFY_MSG_CODEX_STOPPED } from '../constants.js';
 
 // Minimal Codex wrapper: spawn `codex`, mirror I/O, and notify after inactivity.
@@ -31,6 +33,7 @@ export default class CodexWrapper {
       if (this.appState === 'working') {
         this.appState = 'notified';
         try {
+          writeNotificationEvent({ project: path.basename(process.cwd()), message: NOTIFY_MSG_CODEX_STOPPED });
           await this.notificationService.send(NOTIFY_TITLE_CODEX, NOTIFY_MSG_CODEX_STOPPED);
         } catch (err) {
           this.logger.error(`Notification error: ${err.message || err}`);

--- a/src/notification-event.js
+++ b/src/notification-event.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const EVENT_FILE = path.join(os.homedir(), '.heyagent', 'last-notification.json');
+
+/**
+ * Write a notification event file before sending a notification.
+ * External tools can read ~/.heyagent/last-notification.json to
+ * identify which project triggered the most recent notification.
+ * Written synchronously so it's available before the notification fires.
+ */
+export function writeNotificationEvent({ project, sessionId, message }) {
+  try {
+    const dir = path.dirname(EVENT_FILE);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(
+      EVENT_FILE,
+      JSON.stringify({
+        project,
+        sessionId: sessionId || null,
+        message,
+        timestamp: Date.now(),
+      }),
+    );
+  } catch {
+    // Best effort - don't block notifications
+  }
+}

--- a/src/notification.js
+++ b/src/notification.js
@@ -8,7 +8,7 @@ class NotificationService {
     this.logger = new Logger('notification');
   }
 
-  async send(title, message) {
+  async send(title, message, subtitle) {
     if (!title) throw new Error('Notification title is required');
     if (!message) throw new Error('Notification message is required');
 
@@ -31,7 +31,7 @@ class NotificationService {
     } else if (method === 'webhook') {
       this.sendCustomWebhookNotification(title, message);
     } else {
-      this.sendDesktopNotification(title, message);
+      this.sendDesktopNotification(title, message, subtitle);
     }
   }
 
@@ -99,11 +99,12 @@ class NotificationService {
     this.logger.info(`Webhook notification sent to ${webhookUrl}`);
   }
 
-  sendDesktopNotification(title, message) {
+  sendDesktopNotification(title, message, subtitle) {
     const isMacOS = process.platform === 'darwin';
     const options = {
       title: title,
       message: message,
+      subtitle: subtitle || undefined,
       sound: true,
       wait: false,
       timeout: 5,


### PR DESCRIPTION
Before sending a notification, write ~/.heyagent/last-notification.json with the project name, session ID, message, and timestamp. External tools can read this to identify which project triggered a notification.

Also adds an optional subtitle param to desktop notifications, passing the project name so it shows in the notification bubble.