### PR TITLE
Feat: Select existing Codex or Claude sessions (/sessions and via /projects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Inside Telegram:
 - `/new` force next prompt to run as a new session
 - `/claude` switch active provider to Claude
 - `/codex` switch active provider to Codex
+- `/projects` choose a project, then continue an existing session or start `New Claude` / `New Codex` where available
+- `/sessions` choose one of the 10 most recent Claude or Codex sessions from all local projects
 - `/status` show provider, directory, bot, session, and pairing
 - `/stop` stop current execution and clear queued messages
 
@@ -91,6 +93,8 @@ When running in an interactive terminal, HeyAgent also accepts live local input.
 - `/stop` stop current execution and clear queued Telegram messages
 - `/claude` switch to Claude provider
 - `/codex` switch to Codex provider
+- `/projects` send a project picker to Telegram
+- `/sessions` send the 10 most recent sessions to Telegram
 - `/status` print local bridge status
 - `/help` show local commands
 - `/exit` stop the running bridge

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:watch:claude": "node --watch --watch-path=src --watch-path=bin --watch-preserve-output ./bin/hey.js claude",
     "dev:watch:codex": "node --watch --watch-path=src --watch-path=bin --watch-preserve-output ./bin/hey.js codex",
     "dev:watch:status": "node --watch --watch-path=src --watch-path=bin --watch-preserve-output ./bin/hey.js status",
+    "test": "node --test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -14,6 +14,7 @@ import { runClaudePrompt } from './providers/claude-provider.js';
 import { runCodexPrompt } from './providers/codex-provider.js';
 import { applyDefaultBypassArgs } from './args.js';
 import { formatSleepInhibitorStatus, startSleepInhibitor } from './sleep-inhibitor.js';
+import { SessionPicker, normalizeCommandName } from './session-picker.js';
 
 const BOTFATHER_URL = 'https://t.me/BotFather';
 const SETUP_MODE_PHONE = 'phone_onboarding';
@@ -74,7 +75,7 @@ function makePairCode() {
   }
 }
 
-function buildStatusText(config, provider, providerArgs = [], sleepInhibitorState = null) {
+function buildStatusText(config, provider, providerArgs = [], sleepInhibitorState = null, selectedSessionCwd = null) {
   const bot = config.telegramBotUsername ? `@${config.telegramBotUsername}` : 'not set';
   const sessionId = getCurrentSessionId(config, provider);
   const argsText = Array.isArray(providerArgs) && providerArgs.length > 0 ? providerArgs.join(' ') : '(none)';
@@ -84,10 +85,13 @@ function buildStatusText(config, provider, providerArgs = [], sleepInhibitorStat
     `Args: ${argsText}`,
     `Sleep prevention: ${sleepStatus}`,
     `Directory: ${process.cwd()}`,
+    selectedSessionCwd ? `Selected session directory: ${selectedSessionCwd}` : null,
     `Bot: ${bot}`,
     `Chat: ${config.telegramChatId || 'not paired'}`,
     `Session: ${sessionId || '-'}`,
-  ].join('\n');
+  ]
+    .filter(Boolean)
+    .join('\n');
 }
 
 function isPairStartMessage(text, code) {
@@ -149,6 +153,8 @@ class Bridge {
     this.activePromptAbortReason = null;
     this.telegramPendingMessages = [];
     this.telegramDispatchScheduled = false;
+    this.sessionPicker = new SessionPicker(this, { gatherSessions: options.gatherSessions });
+    this.selectedSessionCwd = null;
 
     this.onSignal = () => {
       this.requestStopCurrentPrompt('shutdown');
@@ -271,6 +277,7 @@ class Bridge {
     const sourceLabel = source === 'cli' ? 'CLI' : 'Telegram';
     const args = splitArgs(rawArgs);
     const effective = this.switchProvider(provider);
+    this.selectedSessionCwd = null;
     const sessionId = this.getBoundSessionId() || '-';
     const argsText = effective.providerArgs.length > 0 ? effective.providerArgs.join(' ') : '(none)';
 
@@ -363,6 +370,8 @@ class Bridge {
           '/stop - stop current execution and clear queued Telegram messages',
           '/claude - switch to Claude provider',
           '/codex - switch to Codex provider',
+          '/projects - choose a project, then continue or start a session',
+          '/sessions - choose one of the 10 most recent sessions in Telegram',
           '/say <text> - send a raw message to Telegram',
           '/ask <prompt> - run prompt through provider and send response to Telegram',
           '/exit - stop HeyAgent',
@@ -374,7 +383,7 @@ class Bridge {
     }
 
     if (line === '/status') {
-      this.writeCliLine(buildStatusText(this.config, this.provider, this.providerArgs, this.sleepInhibitorState));
+      this.writeCliLine(buildStatusText(this.config, this.provider, this.providerArgs, this.sleepInhibitorState, this.selectedSessionCwd));
       return;
     }
 
@@ -407,6 +416,16 @@ class Bridge {
     if (line === '/codex' || line.startsWith('/codex ')) {
       const argument = line.slice('/codex'.length).trim();
       await this.handleProviderSwitchCommand('codex', argument, 'cli');
+      return;
+    }
+
+    if (line === '/sessions') {
+      await this.sessionPicker.showSessionPicker();
+      return;
+    }
+
+    if (line === '/projects') {
+      await this.sessionPicker.showProjectPicker();
       return;
     }
 
@@ -631,6 +650,8 @@ class Bridge {
         this.config.clearPairing();
       }
 
+      await this.sessionPicker.configureTelegramCommands(telegram);
+
       return true;
     } catch (error) {
       if (error instanceof TelegramApiError && error.status === 401) {
@@ -653,6 +674,7 @@ class Bridge {
     }
 
     this.forceNewNextPrompt = true;
+    this.selectedSessionCwd = null;
     this.config.setMany(updates);
   }
 
@@ -904,6 +926,11 @@ class Bridge {
           continue;
         }
 
+        if (message.type === 'callback') {
+          await this.sessionPicker.handleCallback(message);
+          continue;
+        }
+
         if (message.text && message.text.trim().startsWith('/')) {
           this.logCliEvent('Telegram command', message.text);
         }
@@ -1003,7 +1030,7 @@ class Bridge {
       .trim()
       .split(/\s+/)
       .filter(Boolean);
-    const command = String(parts[0] || '').toLowerCase();
+    const command = normalizeCommandName(parts[0]);
     const argument = parts.slice(1).join(' ').trim();
 
     if (command === '/help') {
@@ -1015,6 +1042,8 @@ class Bridge {
           '/stop - stop current execution and clear queued messages',
           '/claude - switch to Claude provider',
           '/codex - switch to Codex provider',
+          '/projects - choose a project, then continue or start a session',
+          '/sessions - choose one of the 10 most recent sessions',
           '/status - show current status',
           '',
           `Send any normal message to talk to ${this.provider}.`,
@@ -1040,8 +1069,18 @@ class Bridge {
       return;
     }
 
+    if (command === '/sessions') {
+      await this.sessionPicker.showSessionPicker();
+      return;
+    }
+
+    if (command === '/projects') {
+      await this.sessionPicker.showProjectPicker();
+      return;
+    }
+
     if (command === '/status') {
-      await this.safeSendMessage(buildStatusText(this.config, this.provider, this.providerArgs, this.sleepInhibitorState));
+      await this.safeSendMessage(buildStatusText(this.config, this.provider, this.providerArgs, this.sleepInhibitorState, this.selectedSessionCwd));
       return;
     }
 
@@ -1064,12 +1103,13 @@ class Bridge {
 
   async runProvider(prompt, resume, options = {}) {
     const abortSignal = options.abortSignal || null;
+    const cwd = this.selectedSessionCwd || process.cwd();
 
     if (this.provider === 'claude') {
       return runClaudePrompt(prompt, {
         resume,
         extraArgs: this.providerArgs,
-        cwd: process.cwd(),
+        cwd,
         abortSignal,
         sessionId: this.config.claudeLastSessionId,
         onSessionId: sessionId => {
@@ -1082,7 +1122,7 @@ class Bridge {
       return runCodexPrompt(prompt, {
         resume,
         extraArgs: this.providerArgs,
-        cwd: process.cwd(),
+        cwd,
         abortSignal,
         sessionId: this.config.codexLastSessionId,
         onSessionId: sessionId => {
@@ -1105,7 +1145,7 @@ class Bridge {
     this.logCliEvent(`${from} -> Telegram`, text);
 
     try {
-      await this.telegram.sendMessage(chatId, text);
+      await this.telegram.sendMessage(chatId, text, options);
     } catch (error) {
       this.logger.error(`Outbox send failed: ${error.message}`);
 

--- a/src/session-picker.js
+++ b/src/session-picker.js
@@ -1,0 +1,496 @@
+import crypto from 'node:crypto';
+import { gatherSessions } from './sessions.js';
+
+const PROVIDER_ORDER = ['claude', 'codex'];
+const SESSION_PICKER_LIMIT = 20;
+const RECENT_SESSION_PICKER_LIMIT = 10;
+const SESSION_BUTTON_MAX_LENGTH = 64;
+
+function formatProviderName(provider) {
+  if (provider === 'claude') {
+    return 'Claude';
+  }
+  if (provider === 'codex') {
+    return 'Codex';
+  }
+  return String(provider || 'Provider');
+}
+
+function normalizeProviderList(providers, fallback = PROVIDER_ORDER) {
+  const values = new Set(Array.isArray(providers) ? providers : []);
+  const normalized = PROVIDER_ORDER.filter(provider => values.has(provider));
+  if (normalized.length > 0) {
+    return normalized;
+  }
+
+  const fallbackValues = new Set(Array.isArray(fallback) ? fallback : []);
+  return PROVIDER_ORDER.filter(provider => fallbackValues.has(provider));
+}
+
+function getSessionProviders(sessions) {
+  const providers = new Set();
+  for (const session of Array.isArray(sessions) ? sessions : []) {
+    if (session?.agentType === 'claude' || session?.agentType === 'codex') {
+      providers.add(session.agentType);
+    }
+  }
+  return PROVIDER_ORDER.filter(provider => providers.has(provider));
+}
+
+function resolveVisibleProviders(sessions, fallbackProvider = 'codex') {
+  const sessionProviders = getSessionProviders(sessions);
+  if (sessionProviders.length > 0) {
+    return sessionProviders;
+  }
+  return normalizeProviderList([fallbackProvider], PROVIDER_ORDER);
+}
+
+function createTelegramBotCommands(visibleProviders = PROVIDER_ORDER) {
+  const providers = new Set(normalizeProviderList(visibleProviders, PROVIDER_ORDER));
+  return [
+    { command: 'help', description: 'Show command list' },
+    { command: 'new', description: 'Start a fresh session' },
+    { command: 'stop', description: 'Stop current execution' },
+    providers.has('claude') ? { command: 'claude', description: 'Switch to Claude' } : null,
+    providers.has('codex') ? { command: 'codex', description: 'Switch to Codex' } : null,
+    { command: 'projects', description: 'Choose project' },
+    { command: 'sessions', description: 'Choose session' },
+    { command: 'status', description: 'Show current status' },
+  ].filter(Boolean);
+}
+
+function truncateLabel(text, maxLength = SESSION_BUTTON_MAX_LENGTH) {
+  const value = String(text || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function formatRelativeAge(timestamp, now = new Date()) {
+  if (!timestamp) {
+    return null;
+  }
+
+  const thenMs = new Date(timestamp).getTime();
+  const nowMs = now instanceof Date ? now.getTime() : new Date(now).getTime();
+  if (!Number.isFinite(thenMs) || !Number.isFinite(nowMs)) {
+    return null;
+  }
+
+  const seconds = Math.max(0, Math.floor((nowMs - thenMs) / 1000));
+  if (seconds < 60) {
+    return 'now';
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 7) {
+    return `${days}d`;
+  }
+  if (days < 30) {
+    return `${Math.floor(days / 7)}w`;
+  }
+  if (days < 365) {
+    return `${Math.floor(days / 30)}mo`;
+  }
+  return `${Math.floor(days / 365)}y`;
+}
+
+function formatSessionButtonLabel(session, now = new Date()) {
+  const provider = formatProviderName(session?.agentType || 'provider');
+  const title = String(session?.title || session?.lastUserMessage || session?.id || 'Untitled session')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const age = formatRelativeAge(session?.lastUserMessageAt, now);
+  const meta = age ? `${provider} · ${age}` : provider;
+
+  return truncateLabel(`${title} (${meta})`);
+}
+
+function normalizeProjectName(project) {
+  return String(project || 'unknown').trim() || 'unknown';
+}
+
+function normalizeCommandName(command) {
+  return String(command || '')
+    .toLowerCase()
+    .split('@')[0];
+}
+
+function groupSessionsByProject(sessions, options = {}) {
+  const limit = Number.isFinite(options.limit) ? Math.max(0, Number(options.limit)) : Infinity;
+  const groupsByProject = new Map();
+
+  for (const session of (Array.isArray(sessions) ? sessions : []).slice(0, limit)) {
+    const project = normalizeProjectName(session?.project);
+    if (!groupsByProject.has(project)) {
+      groupsByProject.set(project, {
+        project,
+        cwd: session?.cwd || null,
+        sessions: [],
+      });
+    }
+    groupsByProject.get(project).sessions.push(session);
+  }
+
+  return [...groupsByProject.values()];
+}
+
+function formatProjectButtonLabel(group) {
+  const sessions = Array.isArray(group?.sessions) ? group.sessions : [];
+  const project = normalizeProjectName(group?.project || sessions[0]?.project);
+
+  return truncateLabel(`${project} (${sessions.length})`);
+}
+
+function createSessionKeyboard(sessions, registerToken, options = {}) {
+  const limit = Number.isFinite(options.limit) ? Math.max(0, Number(options.limit)) : SESSION_PICKER_LIMIT;
+  const now = options.now || new Date();
+  const rows = [];
+
+  for (const session of (Array.isArray(sessions) ? sessions : []).slice(0, limit)) {
+    const token = registerToken(session);
+    rows.push([
+      {
+        text: formatSessionButtonLabel(session, now),
+        callback_data: token,
+      },
+    ]);
+  }
+
+  return {
+    inline_keyboard: rows,
+  };
+}
+
+function createSessionProjectKeyboard(sessions, registerProjectToken, options = {}) {
+  const rows = [];
+
+  for (const group of groupSessionsByProject(sessions, options)) {
+    rows.push([
+      {
+        text: formatProjectButtonLabel(group),
+        callback_data: registerProjectToken(group),
+      },
+    ]);
+  }
+
+  return {
+    inline_keyboard: rows,
+  };
+}
+
+function createProjectSessionKeyboard(group, registerSessionToken, registerNewSessionToken, options = {}) {
+  const sessions = Array.isArray(group?.sessions) ? group.sessions : [];
+  const project = normalizeProjectName(group?.project || sessions[0]?.project);
+  const cwd = group?.cwd || sessions.find(session => session?.cwd)?.cwd || null;
+  const limit = Number.isFinite(options.limit) ? Math.max(0, Number(options.limit)) : SESSION_PICKER_LIMIT;
+  const now = options.now || new Date();
+  const visibleProviders = new Set(normalizeProviderList(options.visibleProviders || PROVIDER_ORDER, PROVIDER_ORDER));
+  const projectProviders = getSessionProviders(sessions).filter(provider => visibleProviders.has(provider));
+  const rows = [];
+
+  if (projectProviders.length > 0 && typeof registerNewSessionToken === 'function') {
+    rows.push(
+      projectProviders.map(provider => ({
+        text: `New ${formatProviderName(provider)}`,
+        callback_data: registerNewSessionToken({
+          provider,
+          project,
+          cwd,
+        }),
+      }))
+    );
+  }
+
+  for (const session of sessions.slice(0, limit)) {
+    rows.push([
+      {
+        text: formatSessionButtonLabel(session, now),
+        callback_data: registerSessionToken(session),
+      },
+    ]);
+  }
+
+  return {
+    inline_keyboard: rows,
+  };
+}
+
+function makePickerToken(prefix, counter) {
+  const tokenNonce = crypto
+    .randomBytes(4)
+    .toString('base64url')
+    .replace(/[^a-zA-Z0-9_-]/g, '');
+  return `${prefix}_${Date.now().toString(36)}_${counter.toString(36)}_${tokenNonce}`;
+}
+
+// Stateful controller for the Telegram session/project pickers. It owns the
+// short-lived callback-token registries and drives the picker conversation,
+// delegating session-switch side effects back to the host Bridge.
+class SessionPicker {
+  constructor(host, options = {}) {
+    this.host = host;
+    this.gatherSessions = typeof options.gatherSessions === 'function' ? options.gatherSessions : gatherSessions;
+    this.visibleProviders = null;
+    this.sessionPickerEntries = new Map();
+    this.sessionPickerProjectEntries = new Map();
+    this.newSessionProjectEntries = new Map();
+    this.sessionPickerCounter = 0;
+  }
+
+  async configureTelegramCommands(telegram = this.host.telegram) {
+    if (!telegram || typeof telegram.setCommands !== 'function') {
+      return;
+    }
+
+    let commands = createTelegramBotCommands(this.visibleProviders || [this.host.provider]);
+    try {
+      const sessions = await this.gatherSessions();
+      this.visibleProviders = resolveVisibleProviders(sessions, this.host.provider);
+      commands = createTelegramBotCommands(this.visibleProviders);
+    } catch (error) {
+      this.host.logger.warn(`Failed to inspect local sessions for Telegram commands: ${error.message}`);
+    }
+
+    try {
+      await telegram.setCommands(commands, { chatId: this.host.config.telegramChatId });
+    } catch (error) {
+      this.host.logger.warn(`Failed to configure Telegram bot commands: ${error.message}`);
+    }
+  }
+
+  registerSessionPickerEntry(session) {
+    const token = makePickerToken('sess', this.sessionPickerCounter);
+    this.sessionPickerCounter += 1;
+    this.sessionPickerEntries.set(token, session);
+    return token;
+  }
+
+  registerSessionPickerProject(group) {
+    const token = makePickerToken('proj', this.sessionPickerCounter);
+    this.sessionPickerCounter += 1;
+    this.sessionPickerProjectEntries.set(token, group);
+    return token;
+  }
+
+  registerNewSessionProject(entry) {
+    const token = makePickerToken('new', this.sessionPickerCounter);
+    this.sessionPickerCounter += 1;
+    this.newSessionProjectEntries.set(token, entry);
+    return token;
+  }
+
+  async showSessionPicker() {
+    this.host.logCliEvent('Session picker', 'loading latest Claude and Codex sessions');
+    const sessions = await this.gatherSessions();
+    this.visibleProviders = resolveVisibleProviders(sessions, this.host.provider);
+    const recentSessions = sessions.slice(0, RECENT_SESSION_PICKER_LIMIT);
+
+    if (recentSessions.length === 0) {
+      await this.host.safeSendMessage('Geen Claude- of Codex-sessies gevonden.');
+      return;
+    }
+
+    this.sessionPickerEntries.clear();
+    this.sessionPickerProjectEntries.clear();
+    this.newSessionProjectEntries.clear();
+    const replyMarkup = createSessionKeyboard(recentSessions, session => this.registerSessionPickerEntry(session), {
+      limit: RECENT_SESSION_PICKER_LIMIT,
+    });
+    await this.host.safeSendMessage(`Kies een sessie (${recentSessions.length} meest recent):`, {
+      replyMarkup,
+    });
+  }
+
+  async showProjectPicker() {
+    this.host.logCliEvent('Project picker', 'loading Claude and Codex projects');
+    const sessions = await this.gatherSessions();
+    this.visibleProviders = resolveVisibleProviders(sessions, this.host.provider);
+    const groups = groupSessionsByProject(sessions);
+
+    if (groups.length === 0) {
+      await this.host.safeSendMessage('Geen Claude- of Codex-projecten gevonden.');
+      return;
+    }
+
+    this.sessionPickerEntries.clear();
+    this.sessionPickerProjectEntries.clear();
+    this.newSessionProjectEntries.clear();
+    const replyMarkup = createSessionProjectKeyboard(sessions, group => this.registerSessionPickerProject(group));
+    const projectSuffix = groups.length === 1 ? 'project' : 'projecten';
+    await this.host.safeSendMessage(`Kies een project (${groups.length} ${projectSuffix}):`, {
+      replyMarkup,
+    });
+  }
+
+  async answerCallback(callbackQueryId, text = '') {
+    if (!this.host.telegram || !callbackQueryId) {
+      return;
+    }
+
+    try {
+      await this.host.telegram.answerCallbackQuery(callbackQueryId, text);
+    } catch (error) {
+      this.host.logger.warn(`Failed to answer Telegram callback: ${error.message}`);
+    }
+  }
+
+  async handleCallback(callback) {
+    const data = String(callback?.data || '').trim();
+    if (data.startsWith('proj_')) {
+      await this.handleSessionProjectCallback(callback);
+      return;
+    }
+
+    if (data.startsWith('new_')) {
+      await this.handleNewSessionCallback(callback);
+      return;
+    }
+
+    if (!data.startsWith('sess_')) {
+      await this.answerCallback(callback.callbackQueryId);
+      return;
+    }
+
+    await this.handleSessionPickerCallback(callback);
+  }
+
+  async handleSessionProjectCallback(callback) {
+    const token = String(callback?.data || '').trim();
+    const group = this.sessionPickerProjectEntries.get(token);
+
+    if (!group) {
+      await this.answerCallback(callback.callbackQueryId, 'Project verlopen');
+      await this.host.safeSendMessage('Deze projectkeuze is verlopen. Stuur opnieuw /projects.');
+      return;
+    }
+
+    const sessions = Array.isArray(group.sessions) ? group.sessions : [];
+    if (sessions.length === 0) {
+      await this.answerCallback(callback.callbackQueryId, 'Geen sessies');
+      await this.host.safeSendMessage('Geen sessies gevonden voor dit project. Stuur opnieuw /projects.');
+      return;
+    }
+
+    this.sessionPickerEntries.clear();
+    this.newSessionProjectEntries.clear();
+    const project = normalizeProjectName(group.project);
+    const visibleProviders = this.visibleProviders || resolveVisibleProviders(sessions, this.host.provider);
+    const replyMarkup = createProjectSessionKeyboard(
+      group,
+      session => this.registerSessionPickerEntry(session),
+      entry => this.registerNewSessionProject(entry),
+      {
+        visibleProviders,
+        limit: SESSION_PICKER_LIMIT,
+      }
+    );
+    await this.answerCallback(callback.callbackQueryId, project);
+    await this.host.safeSendMessage(`Kies een sessie voor ${project}:`, { replyMarkup });
+  }
+
+  async handleNewSessionCallback(callback) {
+    const token = String(callback?.data || '').trim();
+    const entry = this.newSessionProjectEntries.get(token);
+
+    if (!entry) {
+      await this.answerCallback(callback.callbackQueryId, 'Keuze verlopen');
+      await this.host.safeSendMessage('Deze nieuwe-sessiekeuze is verlopen. Stuur opnieuw /projects.');
+      return;
+    }
+
+    if (entry.provider !== 'claude' && entry.provider !== 'codex') {
+      await this.answerCallback(callback.callbackQueryId, 'Onbekende provider');
+      await this.host.safeSendMessage(`Unsupported session provider: ${entry.provider || 'unknown'}`);
+      return;
+    }
+
+    this.host.requestStopCurrentPrompt('session_switch');
+    this.host.clearQueuedTelegramMessages();
+    this.host.switchProvider(entry.provider);
+    this.host.setBoundSessionId(null);
+    this.host.selectedSessionCwd = entry.cwd || null;
+    this.host.forceNewNextPrompt = true;
+    this.newSessionProjectEntries.delete(token);
+
+    const providerLabel = formatProviderName(entry.provider);
+    const project = normalizeProjectName(entry.project);
+    await this.answerCallback(callback.callbackQueryId, `New ${providerLabel}`);
+    await this.host.safeSendMessage(
+      [
+        `New ${providerLabel} session selected.`,
+        `Project: ${project}`,
+        entry.cwd ? `Directory: ${entry.cwd}` : null,
+        'Your next message starts a fresh session.',
+      ]
+        .filter(Boolean)
+        .join('\n')
+    );
+  }
+
+  async handleSessionPickerCallback(callback) {
+    const token = String(callback?.data || '').trim();
+    const session = this.sessionPickerEntries.get(token);
+
+    if (!session) {
+      await this.answerCallback(callback.callbackQueryId, 'Sessie verlopen');
+      await this.host.safeSendMessage('Deze sessiekeuze is verlopen. Stuur opnieuw /sessions.');
+      return;
+    }
+
+    if (session.agentType !== 'claude' && session.agentType !== 'codex') {
+      await this.answerCallback(callback.callbackQueryId, 'Onbekende provider');
+      await this.host.safeSendMessage(`Unsupported session provider: ${session.agentType || 'unknown'}`);
+      return;
+    }
+
+    this.host.requestStopCurrentPrompt('session_switch');
+    this.host.clearQueuedTelegramMessages();
+    this.host.switchProvider(session.agentType);
+    this.host.setBoundSessionId(session.id);
+    this.host.selectedSessionCwd = session.cwd || null;
+    this.host.forceNewNextPrompt = false;
+    this.sessionPickerEntries.delete(token);
+
+    const providerLabel = formatProviderName(session.agentType);
+    const project = session.project || 'unknown';
+    const title = session.title || session.lastUserMessage || session.id;
+    await this.answerCallback(callback.callbackQueryId, `${providerLabel} geselecteerd`);
+    await this.host.safeSendMessage(
+      [`Selected ${providerLabel} session.`, `Project: ${project}`, `Session: ${session.id}`, title ? `Title: ${title}` : null]
+        .filter(Boolean)
+        .join('\n')
+    );
+  }
+}
+
+export {
+  SessionPicker,
+  PROVIDER_ORDER,
+  SESSION_PICKER_LIMIT,
+  RECENT_SESSION_PICKER_LIMIT,
+  SESSION_BUTTON_MAX_LENGTH,
+  normalizeProviderList,
+  getSessionProviders,
+  resolveVisibleProviders,
+  createTelegramBotCommands,
+  truncateLabel,
+  formatSessionButtonLabel,
+  normalizeProjectName,
+  normalizeCommandName,
+  groupSessionsByProject,
+  formatProjectButtonLabel,
+  createSessionKeyboard,
+  createSessionProjectKeyboard,
+  createProjectSessionKeyboard,
+};

--- a/src/session-picker.js
+++ b/src/session-picker.js
@@ -297,7 +297,7 @@ class SessionPicker {
     const recentSessions = sessions.slice(0, RECENT_SESSION_PICKER_LIMIT);
 
     if (recentSessions.length === 0) {
-      await this.host.safeSendMessage('Geen Claude- of Codex-sessies gevonden.');
+      await this.host.safeSendMessage('No Claude or Codex sessions found.');
       return;
     }
 
@@ -377,8 +377,8 @@ class SessionPicker {
 
     const sessions = Array.isArray(group.sessions) ? group.sessions : [];
     if (sessions.length === 0) {
-      await this.answerCallback(callback.callbackQueryId, 'Geen sessies');
-      await this.host.safeSendMessage('Geen sessies gevonden voor dit project. Stuur opnieuw /projects.');
+      await this.answerCallback(callback.callbackQueryId, 'No sessions');
+      await this.host.safeSendMessage('No sessions found for this project. Send /projects again.');
       return;
     }
 

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -1,0 +1,375 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { homedir } from 'node:os';
+
+const DEFAULT_MAX_AGE_DAYS = 90;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function safeReaddir(dir) {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function isDirectory(filePath) {
+  try {
+    return statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function findJsonlFiles(dir, maxDepth = 4, depth = 0) {
+  if (depth > maxDepth) {
+    return [];
+  }
+
+  const results = [];
+  for (const entry of safeReaddir(dir)) {
+    const filePath = join(dir, entry);
+    if (isDirectory(filePath)) {
+      results.push(...findJsonlFiles(filePath, maxDepth, depth + 1));
+    } else if (entry.endsWith('.jsonl')) {
+      results.push(filePath);
+    }
+  }
+  return results;
+}
+
+function findJsonFiles(dir, maxDepth = 4, depth = 0) {
+  if (depth > maxDepth) {
+    return [];
+  }
+
+  const results = [];
+  for (const entry of safeReaddir(dir)) {
+    const filePath = join(dir, entry);
+    if (isDirectory(filePath)) {
+      results.push(...findJsonFiles(filePath, maxDepth, depth + 1));
+    } else if (entry.endsWith('.json')) {
+      results.push(filePath);
+    }
+  }
+  return results;
+}
+
+function readJsonLines(filePath) {
+  const content = readFileSync(filePath, 'utf8');
+  const parsed = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    try {
+      parsed.push(JSON.parse(trimmed));
+    } catch {
+      // Ignore corrupt JSONL lines. A single bad line should not hide the session list.
+    }
+  }
+
+  return parsed;
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function truncate(text, maxLength) {
+  const value = typeof text === 'string' ? text.trim() : '';
+  if (!value) {
+    return null;
+  }
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function projectPathFromClaudeKey(projectKey) {
+  const parts = String(projectKey || '')
+    .split('-')
+    .filter(Boolean);
+  return parts.length > 0 ? `/${parts.join('/')}` : null;
+}
+
+function projectNameFromPath(cwd) {
+  if (!cwd) {
+    return null;
+  }
+  return cwd.split('/').filter(Boolean).pop() || null;
+}
+
+function simplifyModel(model) {
+  const value = typeof model === 'string' ? model : '';
+  if (!value) {
+    return null;
+  }
+  if (value.includes('opus')) {
+    return 'opus';
+  }
+  if (value.includes('sonnet')) {
+    return 'sonnet';
+  }
+  if (value.includes('haiku')) {
+    return 'haiku';
+  }
+  return value;
+}
+
+function extractClaudeUserTexts(entry) {
+  if (entry?.type !== 'user') {
+    return [];
+  }
+
+  const content = entry.message?.content;
+  if (typeof content === 'string' && content.trim()) {
+    return [content.trim()];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  return content.filter(block => block?.type === 'text' && typeof block.text === 'string' && block.text.trim()).map(block => block.text.trim());
+}
+
+function extractCodexUserText(entry) {
+  if (entry?.type !== 'response_item' || entry.payload?.role !== 'user') {
+    return '';
+  }
+
+  const content = entry.payload?.content;
+  if (!Array.isArray(content)) {
+    return '';
+  }
+
+  const textBlock = content.find(block => {
+    const text = typeof block?.text === 'string' ? block.text.trim() : '';
+    return block?.type === 'input_text' && text && !text.startsWith('<');
+  });
+
+  return typeof textBlock?.text === 'string' ? textBlock.text.trim() : '';
+}
+
+function readCodexSessionTitles(homeDir) {
+  const titles = new Map();
+  const indexPath = join(homeDir, '.codex', 'session_index.jsonl');
+  if (!existsSync(indexPath)) {
+    return titles;
+  }
+
+  for (const entry of readJsonLines(indexPath)) {
+    const id = typeof entry?.id === 'string' ? entry.id.trim() : '';
+    const title = truncate(entry?.thread_name, 80);
+    if (id && title) {
+      titles.set(id, title);
+    }
+  }
+
+  return titles;
+}
+
+function readClaudeSessionTitles(homeDir) {
+  const titles = new Map();
+  const sessionsDir = join(homeDir, 'Library', 'Application Support', 'Claude', 'claude-code-sessions');
+  if (!existsSync(sessionsDir)) {
+    return titles;
+  }
+
+  for (const filePath of findJsonFiles(sessionsDir)) {
+    const entry = readJsonFile(filePath);
+    const cliSessionId = typeof entry?.cliSessionId === 'string' ? entry.cliSessionId.trim() : '';
+    const title = truncate(entry?.title, 80);
+    if (cliSessionId && title) {
+      titles.set(cliSessionId, title);
+    }
+  }
+
+  return titles;
+}
+
+export function parseClaudeSessionFile(filePath, sessionId, projectKey, options = {}) {
+  const entries = readJsonLines(filePath);
+  let firstUserText = null;
+  let lastUserText = null;
+  let lastUserTimestamp = null;
+  let model = null;
+
+  for (const entry of entries) {
+    if (!model && typeof entry.message?.model === 'string') {
+      model = entry.message.model;
+    }
+
+    const userTexts = extractClaudeUserTexts(entry);
+    for (const text of userTexts) {
+      if (!firstUserText) {
+        firstUserText = text;
+      }
+      lastUserText = text;
+      lastUserTimestamp = entry.timestamp || lastUserTimestamp;
+    }
+  }
+
+  if (!lastUserTimestamp) {
+    return null;
+  }
+
+  const cwd = projectPathFromClaudeKey(projectKey);
+
+  return {
+    id: sessionId,
+    agentType: 'claude',
+    title: truncate(options.title, 80) || truncate(firstUserText, 80),
+    lastUserMessage: truncate(lastUserText, 120),
+    lastUserMessageAt: lastUserTimestamp,
+    project: projectNameFromPath(cwd) || projectKey || null,
+    cwd,
+    model: simplifyModel(model),
+    resumable: true,
+  };
+}
+
+export function parseCodexSessionFile(filePath, options = {}) {
+  const entries = readJsonLines(filePath);
+  let sessionId = null;
+  let cwd = null;
+  let model = null;
+  let firstUserText = null;
+  let lastUserText = null;
+  let lastUserTimestamp = null;
+
+  for (const entry of entries) {
+    if (entry?.type === 'session_meta') {
+      sessionId = entry.payload?.id || sessionId;
+      cwd = entry.payload?.cwd || cwd;
+      model = entry.payload?.model || model;
+    }
+
+    const userText = extractCodexUserText(entry);
+    if (userText) {
+      if (!firstUserText) {
+        firstUserText = userText;
+      }
+      lastUserText = userText;
+      lastUserTimestamp = entry.timestamp || lastUserTimestamp;
+    }
+  }
+
+  if (!sessionId || !lastUserTimestamp) {
+    return null;
+  }
+
+  return {
+    id: sessionId,
+    agentType: 'codex',
+    title: truncate(options.title, 80) || truncate(firstUserText, 80),
+    lastUserMessage: truncate(lastUserText, 120),
+    lastUserMessageAt: lastUserTimestamp,
+    project: projectNameFromPath(cwd),
+    cwd: cwd || null,
+    model: model || null,
+    resumable: true,
+  };
+}
+
+function isRecentEnough(filePath, maxAgeDays) {
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) {
+    return true;
+  }
+
+  const stat = statSync(filePath);
+  return Date.now() - stat.mtimeMs <= maxAgeDays * DAY_MS;
+}
+
+async function gatherClaudeSessions(homeDir, maxAgeDays, titleIndex = new Map()) {
+  const projectsDir = join(homeDir, '.claude', 'projects');
+  if (!existsSync(projectsDir)) {
+    return [];
+  }
+
+  const sessions = [];
+  for (const projectKey of safeReaddir(projectsDir)) {
+    const projectDir = join(projectsDir, projectKey);
+    if (!isDirectory(projectDir)) {
+      continue;
+    }
+
+    const files = safeReaddir(projectDir).filter(file => file.endsWith('.jsonl') && !file.includes('subagent'));
+    for (const file of files) {
+      try {
+        const filePath = join(projectDir, file);
+        if (!isRecentEnough(filePath, maxAgeDays)) {
+          continue;
+        }
+
+        const sessionId = basename(file, '.jsonl');
+        const session = parseClaudeSessionFile(filePath, sessionId, projectKey, {
+          title: titleIndex.get(sessionId),
+        });
+        if (session) {
+          sessions.push(session);
+        }
+      } catch {
+        // Skip unreadable files.
+      }
+    }
+  }
+
+  return sessions;
+}
+
+async function gatherCodexSessions(homeDir, maxAgeDays, titleIndex = new Map()) {
+  const sessionsDir = join(homeDir, '.codex', 'sessions');
+  if (!existsSync(sessionsDir)) {
+    return [];
+  }
+
+  const sessions = [];
+  for (const filePath of findJsonlFiles(sessionsDir)) {
+    try {
+      if (!isRecentEnough(filePath, maxAgeDays)) {
+        continue;
+      }
+
+      const session = parseCodexSessionFile(filePath);
+      if (session) {
+        session.title = titleIndex.get(session.id) || session.title;
+        sessions.push(session);
+      }
+    } catch {
+      // Skip unreadable files.
+    }
+  }
+
+  return sessions;
+}
+
+export async function gatherSessions(options = {}) {
+  const homeDir = options.homeDir || homedir();
+  const maxAgeDays = Number.isFinite(options.maxAgeDays) ? options.maxAgeDays : DEFAULT_MAX_AGE_DAYS;
+  const claudeTitles = readClaudeSessionTitles(homeDir);
+  const codexTitles = readCodexSessionTitles(homeDir);
+  const results = await Promise.allSettled([
+    gatherClaudeSessions(homeDir, maxAgeDays, claudeTitles),
+    gatherCodexSessions(homeDir, maxAgeDays, codexTitles),
+  ]);
+  const sessions = [];
+
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      sessions.push(...result.value);
+    }
+  }
+
+  sessions.sort((a, b) => new Date(b.lastUserMessageAt || 0).getTime() - new Date(a.lastUserMessageAt || 0).getTime());
+  return sessions;
+}

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -178,23 +178,31 @@ function readCodexSessionTitles(homeDir) {
   return titles;
 }
 
-function readClaudeSessionTitles(homeDir) {
-  const titles = new Map();
+function isClaudeMetadataArchived(entry) {
+  return entry?.isArchived === true || entry?.archived === true || entry?.status === 'archived';
+}
+
+function readClaudeSessionMetadata(homeDir) {
+  const sessions = new Map();
   const sessionsDir = join(homeDir, 'Library', 'Application Support', 'Claude', 'claude-code-sessions');
   if (!existsSync(sessionsDir)) {
-    return titles;
+    return sessions;
   }
 
   for (const filePath of findJsonFiles(sessionsDir)) {
     const entry = readJsonFile(filePath);
     const cliSessionId = typeof entry?.cliSessionId === 'string' ? entry.cliSessionId.trim() : '';
     const title = truncate(entry?.title, 80);
-    if (cliSessionId && title) {
-      titles.set(cliSessionId, title);
+    if (cliSessionId) {
+      const existing = sessions.get(cliSessionId) || {};
+      sessions.set(cliSessionId, {
+        title: existing.title || title,
+        archived: existing.archived || isClaudeMetadataArchived(entry),
+      });
     }
   }
 
-  return titles;
+  return sessions;
 }
 
 export function parseClaudeSessionFile(filePath, sessionId, projectKey, options = {}) {
@@ -290,7 +298,7 @@ function isRecentEnough(filePath, maxAgeDays) {
   return Date.now() - stat.mtimeMs <= maxAgeDays * DAY_MS;
 }
 
-async function gatherClaudeSessions(homeDir, maxAgeDays, titleIndex = new Map()) {
+async function gatherClaudeSessions(homeDir, maxAgeDays, metadataIndex = new Map()) {
   const projectsDir = join(homeDir, '.claude', 'projects');
   if (!existsSync(projectsDir)) {
     return [];
@@ -312,8 +320,13 @@ async function gatherClaudeSessions(homeDir, maxAgeDays, titleIndex = new Map())
         }
 
         const sessionId = basename(file, '.jsonl');
+        const metadata = metadataIndex.get(sessionId) || {};
+        if (metadata.archived) {
+          continue;
+        }
+
         const session = parseClaudeSessionFile(filePath, sessionId, projectKey, {
-          title: titleIndex.get(sessionId),
+          title: metadata.title,
         });
         if (session) {
           sessions.push(session);
@@ -356,10 +369,10 @@ async function gatherCodexSessions(homeDir, maxAgeDays, titleIndex = new Map()) 
 export async function gatherSessions(options = {}) {
   const homeDir = options.homeDir || homedir();
   const maxAgeDays = Number.isFinite(options.maxAgeDays) ? options.maxAgeDays : DEFAULT_MAX_AGE_DAYS;
-  const claudeTitles = readClaudeSessionTitles(homeDir);
+  const claudeMetadata = readClaudeSessionMetadata(homeDir);
   const codexTitles = readCodexSessionTitles(homeDir);
   const results = await Promise.allSettled([
-    gatherClaudeSessions(homeDir, maxAgeDays, claudeTitles),
+    gatherClaudeSessions(homeDir, maxAgeDays, claudeMetadata),
     gatherCodexSessions(homeDir, maxAgeDays, codexTitles),
   ]);
   const sessions = [];

--- a/src/telegram-api.js
+++ b/src/telegram-api.js
@@ -172,6 +172,39 @@ function normalizeMessage(update) {
   };
 }
 
+function normalizeCallback(update) {
+  const callback = update?.callback_query;
+  const data = typeof callback?.data === 'string' ? callback.data.trim() : '';
+  const callbackQueryId = typeof callback?.id === 'string' ? callback.id.trim() : '';
+
+  if (!callback || !data || !callbackQueryId) {
+    return null;
+  }
+
+  const message = callback.message;
+  return {
+    updateId: Number.isInteger(update.update_id) ? update.update_id : null,
+    type: 'callback',
+    callbackQueryId,
+    data,
+    chatId: message?.chat?.id === undefined || message?.chat?.id === null ? null : String(message.chat.id),
+    chatType: typeof message?.chat?.type === 'string' ? message.chat.type : null,
+    userId: callback.from?.id === undefined || callback.from?.id === null ? null : String(callback.from.id),
+    messageId: Number.isInteger(message?.message_id) ? message.message_id : null,
+  };
+}
+
+function buildSendMessageOptions(options = {}) {
+  const replyMarkup = options.replyMarkup || options.reply_markup || null;
+  if (!replyMarkup) {
+    return {};
+  }
+
+  return {
+    reply_markup: replyMarkup,
+  };
+}
+
 class TelegramApi {
   constructor(token) {
     this.token = token;
@@ -191,6 +224,18 @@ class TelegramApi {
     }
   }
 
+  async setCommands(commands, options = {}) {
+    const normalizedCommands = Array.isArray(commands) ? commands : [];
+    const chatId = Number(options.chatId);
+    const scope = Number.isFinite(chatId) ? { scope: { type: 'chat', chat_id: chatId } } : undefined;
+
+    try {
+      await this.bot.setMyCommands(normalizedCommands, scope);
+    } catch (error) {
+      throw toTelegramError(error, 'Failed to configure Telegram bot commands');
+    }
+  }
+
   async ensurePollingMode() {
     try {
       await this.bot.deleteWebHook({
@@ -204,7 +249,7 @@ class TelegramApi {
   async getUpdates(cursor, timeout = 20) {
     const opts = {
       timeout: Number.isFinite(timeout) ? Math.max(1, Math.min(50, timeout)) : 20,
-      allowed_updates: ['message'],
+      allowed_updates: ['message', 'callback_query'],
     };
 
     if (Number.isFinite(cursor) && cursor >= 0) {
@@ -221,7 +266,7 @@ class TelegramApi {
           nextCursor = update.update_id;
         }
 
-        const normalized = normalizeMessage(update);
+        const normalized = normalizeMessage(update) || normalizeCallback(update);
         if (normalized) {
           messages.push(normalized);
         }
@@ -233,19 +278,36 @@ class TelegramApi {
     }
   }
 
-  async sendMessage(chatId, text) {
+  async sendMessage(chatId, text, options = {}) {
     const targetChatId = String(chatId || '').trim();
     if (!targetChatId) {
       throw new TelegramApiError('Missing Telegram chat ID');
     }
 
     const chunks = splitMessage(text);
+    const sendOptions = buildSendMessageOptions(options);
     try {
-      for (const chunk of chunks) {
-        await this.bot.sendMessage(targetChatId, chunk);
+      for (let index = 0; index < chunks.length; index += 1) {
+        const chunk = chunks[index];
+        await this.bot.sendMessage(targetChatId, chunk, index === 0 ? sendOptions : {});
       }
     } catch (error) {
       throw toTelegramError(error, 'Failed to send Telegram message');
+    }
+  }
+
+  async answerCallbackQuery(callbackQueryId, text = '') {
+    const normalizedCallbackQueryId = String(callbackQueryId || '').trim();
+    if (!normalizedCallbackQueryId) {
+      throw new TelegramApiError('Missing Telegram callback query ID');
+    }
+
+    try {
+      await this.bot.answerCallbackQuery(normalizedCallbackQueryId, {
+        text: String(text || '').trim() || undefined,
+      });
+    } catch (error) {
+      throw toTelegramError(error, 'Failed to answer Telegram callback query');
     }
   }
 
@@ -268,4 +330,4 @@ class TelegramApi {
   }
 }
 
-export { TelegramApi, TelegramApiError };
+export { TelegramApi, TelegramApiError, buildSendMessageOptions, normalizeCallback, normalizeMessage };

--- a/test/session-picker.test.js
+++ b/test/session-picker.test.js
@@ -1,0 +1,805 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import Bridge from '../src/bridge.js';
+import {
+  createProjectSessionKeyboard,
+  createSessionKeyboard,
+  createSessionProjectKeyboard,
+  createTelegramBotCommands,
+  formatSessionButtonLabel,
+  groupSessionsByProject,
+} from '../src/session-picker.js';
+
+function makeSession(index, overrides = {}) {
+  return {
+    id: `session-${index}`,
+    agentType: index % 2 === 0 ? 'codex' : 'claude',
+    title: `Prompt ${index}`,
+    lastUserMessage: `Last prompt ${index}`,
+    lastUserMessageAt: '2026-05-29T09:45:00.000Z',
+    project: `project-${index}`,
+    cwd: `/tmp/project-${index}`,
+    model: null,
+    resumable: true,
+    ...overrides,
+  };
+}
+
+test('formatSessionButtonLabel shows title and provider in parentheses', () => {
+  const label = formatSessionButtonLabel(
+    makeSession(1, {
+      agentType: 'claude',
+      project: 'heyagent',
+      title: 'Add Telegram session picker support',
+    }),
+    new Date('2026-05-29T10:00:00.000Z')
+  );
+
+  assert.equal(label, 'Add Telegram session picker support (Claude · 15m)');
+});
+
+test('formatSessionButtonLabel falls back to last user message', () => {
+  const label = formatSessionButtonLabel(
+    makeSession(2, {
+      agentType: 'codex',
+      project: null,
+      title: null,
+      lastUserMessage: 'Continue from here',
+    }),
+    new Date('2026-05-29T10:00:00.000Z')
+  );
+
+  assert.equal(label, 'Continue from here (Codex · 15m)');
+});
+
+test('formatSessionButtonLabel truncates long labels', () => {
+  const label = formatSessionButtonLabel(
+    makeSession(3, {
+      title: 'This is an intentionally long prompt title that should not take over the Telegram keyboard',
+    }),
+    new Date('2026-05-29T10:02:00.000Z')
+  );
+
+  assert.ok(label.length <= 64);
+  assert.ok(label.endsWith('...'));
+});
+
+test('formatSessionButtonLabel shows hour- and day-level ages', () => {
+  const session = makeSession(4, {
+    agentType: 'claude',
+    title: 'Older work',
+    lastUserMessageAt: '2026-05-29T08:00:00.000Z',
+  });
+
+  assert.equal(formatSessionButtonLabel(session, new Date('2026-05-29T11:00:00.000Z')), 'Older work (Claude · 3h)');
+  assert.equal(formatSessionButtonLabel(session, new Date('2026-06-01T08:00:00.000Z')), 'Older work (Claude · 3d)');
+});
+
+test('createSessionKeyboard limits to 20 sessions and registers callback tokens', () => {
+  const registered = new Map();
+  const sessions = Array.from({ length: 25 }, (_, index) => makeSession(index + 1));
+  const keyboard = createSessionKeyboard(sessions, session => {
+    const token = `sess_${session.id}`;
+    registered.set(token, session);
+    return token;
+  });
+
+  assert.equal(keyboard.inline_keyboard.length, 20);
+  assert.equal(keyboard.inline_keyboard[0][0].callback_data, 'sess_session-1');
+  assert.equal(keyboard.inline_keyboard[19][0].callback_data, 'sess_session-20');
+  assert.equal(registered.size, 20);
+  assert.equal(registered.get('sess_session-1').id, 'session-1');
+});
+
+test('groupSessionsByProject limits before grouping and keeps newest project first', () => {
+  const sessions = Array.from({ length: 25 }, (_, index) =>
+    makeSession(index + 1, {
+      project: index === 24 ? 'outside-limit' : index % 2 === 0 ? 'alpha' : 'beta',
+    })
+  );
+
+  const groups = groupSessionsByProject(sessions, { limit: 20 });
+
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0].project, 'alpha');
+  assert.equal(groups[0].sessions.length, 10);
+  assert.equal(groups[1].project, 'beta');
+  assert.equal(groups[1].sessions.length, 10);
+  assert.equal(
+    groups.some(group => group.project === 'outside-limit'),
+    false
+  );
+});
+
+test('createSessionProjectKeyboard renders every project as a project button with session count', () => {
+  const registeredProjects = new Map();
+  const sessions = [
+    makeSession(1, { id: 'alpha-new', project: 'alpha', agentType: 'claude', title: 'New alpha work' }),
+    makeSession(2, { id: 'beta-only', project: 'beta', agentType: 'codex', title: 'Only beta work' }),
+    makeSession(3, { id: 'alpha-old', project: 'alpha', agentType: 'codex', title: 'Older alpha work' }),
+  ];
+
+  const keyboard = createSessionProjectKeyboard(sessions, group => {
+    const token = `proj_${group.project}`;
+    registeredProjects.set(token, group);
+    return token;
+  });
+
+  assert.equal(keyboard.inline_keyboard.length, 2);
+  assert.equal(keyboard.inline_keyboard[0][0].callback_data, 'proj_alpha');
+  assert.equal(keyboard.inline_keyboard[0][0].text, 'alpha (2)');
+  assert.equal(keyboard.inline_keyboard[1][0].callback_data, 'proj_beta');
+  assert.equal(keyboard.inline_keyboard[1][0].text, 'beta (1)');
+  assert.deepEqual(
+    registeredProjects.get('proj_alpha').sessions.map(session => session.id),
+    ['alpha-new', 'alpha-old']
+  );
+  assert.deepEqual(
+    registeredProjects.get('proj_beta').sessions.map(session => session.id),
+    ['beta-only']
+  );
+});
+
+test('createProjectSessionKeyboard shows new buttons for providers found in the project', () => {
+  const registeredSessions = new Map();
+  const registeredNewSessions = new Map();
+  const group = {
+    project: 'alpha',
+    cwd: '/tmp/alpha',
+    sessions: [
+      makeSession(1, { id: 'alpha-claude', project: 'alpha', cwd: '/tmp/alpha', agentType: 'claude', title: 'Claude alpha' }),
+      makeSession(2, { id: 'alpha-codex', project: 'alpha', cwd: '/tmp/alpha', agentType: 'codex', title: 'Codex alpha' }),
+    ],
+  };
+
+  const keyboard = createProjectSessionKeyboard(
+    group,
+    session => {
+      const token = `sess_${session.id}`;
+      registeredSessions.set(token, session);
+      return token;
+    },
+    entry => {
+      const token = `new_${entry.provider}`;
+      registeredNewSessions.set(token, entry);
+      return token;
+    },
+    { now: new Date('2026-05-29T10:00:00.000Z') }
+  );
+
+  assert.deepEqual(
+    keyboard.inline_keyboard[0].map(button => button.text),
+    ['New Claude', 'New Codex']
+  );
+  assert.equal(keyboard.inline_keyboard[1][0].text, 'Claude alpha (Claude · 15m)');
+  assert.equal(keyboard.inline_keyboard[2][0].text, 'Codex alpha (Codex · 15m)');
+  assert.deepEqual(
+    [...registeredNewSessions.values()],
+    [
+      { provider: 'claude', project: 'alpha', cwd: '/tmp/alpha' },
+      { provider: 'codex', project: 'alpha', cwd: '/tmp/alpha' },
+    ]
+  );
+  assert.equal(registeredSessions.size, 2);
+});
+
+test('createProjectSessionKeyboard hides providers absent from the project', () => {
+  const registeredNewSessions = new Map();
+  const group = {
+    project: 'beta',
+    cwd: '/tmp/beta',
+    sessions: [makeSession(1, { id: 'beta-codex', project: 'beta', cwd: '/tmp/beta', agentType: 'codex', title: 'Codex beta' })],
+  };
+
+  const keyboard = createProjectSessionKeyboard(
+    group,
+    session => `sess_${session.id}`,
+    entry => {
+      const token = `new_${entry.provider}`;
+      registeredNewSessions.set(token, entry);
+      return token;
+    },
+    { visibleProviders: ['codex'], now: new Date('2026-05-29T10:00:00.000Z') }
+  );
+
+  assert.deepEqual(
+    keyboard.inline_keyboard[0].map(button => button.text),
+    ['New Codex']
+  );
+  assert.equal(keyboard.inline_keyboard[1][0].text, 'Codex beta (Codex · 15m)');
+  assert.deepEqual([...registeredNewSessions.values()], [{ provider: 'codex', project: 'beta', cwd: '/tmp/beta' }]);
+});
+
+test('createTelegramBotCommands hides provider switches not in the visible provider set', () => {
+  assert.deepEqual(
+    createTelegramBotCommands(['codex']).map(command => command.command),
+    ['help', 'new', 'stop', 'codex', 'projects', 'sessions', 'status']
+  );
+  assert.deepEqual(
+    createTelegramBotCommands(['claude', 'codex']).map(command => command.command),
+    ['help', 'new', 'stop', 'claude', 'codex', 'projects', 'sessions', 'status']
+  );
+});
+
+test('showSessionPicker sends latest 10 sessions as a flat list', async () => {
+  const data = {
+    provider: 'codex',
+    claudeArgs: [],
+    codexArgs: [],
+    claudeLastSessionId: null,
+    codexLastSessionId: null,
+    telegramChatId: 'chat-1',
+  };
+  const sentMessages = [];
+  const config = {
+    get claudeArgs() {
+      return data.claudeArgs;
+    },
+    get codexArgs() {
+      return data.codexArgs;
+    },
+    get claudeLastSessionId() {
+      return data.claudeLastSessionId;
+    },
+    get codexLastSessionId() {
+      return data.codexLastSessionId;
+    },
+    get telegramChatId() {
+      return data.telegramChatId;
+    },
+    get telegramBotUsername() {
+      return null;
+    },
+    set(key, value) {
+      data[key] = value;
+    },
+    setMany(updates) {
+      Object.assign(data, updates);
+    },
+    clearPairing() {},
+  };
+  const sessions = Array.from({ length: 12 }, (_, index) => makeSession(index + 1, { project: index < 6 ? 'alpha' : 'beta' }));
+  const bridge = new Bridge(config, 'codex', [], {
+    gatherSessions: async () => sessions,
+  });
+  bridge.logCliEvent = () => {};
+  bridge.telegram = {
+    sendMessage(chatId, text, options) {
+      sentMessages.push({ chatId, text, options });
+    },
+  };
+
+  await bridge.sessionPicker.showSessionPicker();
+
+  assert.equal(sentMessages[0].chatId, 'chat-1');
+  assert.match(sentMessages[0].text, /Kies een sessie/);
+  assert.doesNotMatch(sentMessages[0].text, /project/);
+  assert.equal(sentMessages[0].options.replyMarkup.inline_keyboard.length, 10);
+  assert.ok(sentMessages[0].options.replyMarkup.inline_keyboard.every(row => row[0].callback_data.startsWith('sess_')));
+  assert.equal(bridge.sessionPicker.sessionPickerEntries.size, 10);
+  assert.equal(bridge.sessionPicker.sessionPickerProjectEntries.size, 0);
+});
+
+test('handleCommand opens project picker for projects command', async () => {
+  const config = {
+    get claudeArgs() {
+      return [];
+    },
+    get codexArgs() {
+      return [];
+    },
+    get claudeLastSessionId() {
+      return null;
+    },
+    get codexLastSessionId() {
+      return null;
+    },
+    get telegramChatId() {
+      return 'chat-1';
+    },
+    get telegramBotUsername() {
+      return 'RegelneefBot';
+    },
+    set() {},
+    setMany() {},
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  let showProjectPickerCalls = 0;
+  bridge.sessionPicker.showProjectPicker = async () => {
+    showProjectPickerCalls += 1;
+  };
+  bridge.safeSendMessage = async () => {
+    throw new Error('Expected /projects command to open picker');
+  };
+
+  await bridge.handleCommand('/projects@RegelneefBot');
+
+  assert.equal(showProjectPickerCalls, 1);
+});
+
+test('handleSessionPickerCallback selects provider session id and cwd', async () => {
+  const data = {
+    provider: 'claude',
+    claudeArgs: [],
+    codexArgs: [],
+    claudeLastSessionId: null,
+    codexLastSessionId: null,
+    telegramChatId: 'chat-1',
+  };
+  const sentMessages = [];
+  const answeredCallbacks = [];
+  const config = {
+    get claudeArgs() {
+      return data.claudeArgs;
+    },
+    get codexArgs() {
+      return data.codexArgs;
+    },
+    get claudeLastSessionId() {
+      return data.claudeLastSessionId;
+    },
+    get codexLastSessionId() {
+      return data.codexLastSessionId;
+    },
+    get telegramChatId() {
+      return data.telegramChatId;
+    },
+    get telegramBotUsername() {
+      return null;
+    },
+    set(key, value) {
+      data[key] = value;
+    },
+    setMany(updates) {
+      Object.assign(data, updates);
+    },
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  bridge.logCliEvent = () => {};
+  bridge.telegram = {
+    sendMessage(chatId, text) {
+      sentMessages.push({ chatId, text });
+    },
+    answerCallbackQuery(callbackQueryId, text) {
+      answeredCallbacks.push({ callbackQueryId, text });
+    },
+  };
+  const session = makeSession(1, {
+    agentType: 'codex',
+    id: 'codex-session',
+    cwd: '/Users/geert/code/selected',
+    project: 'selected',
+    title: 'Selected work',
+  });
+  bridge.sessionPicker.sessionPickerEntries.set('sess_token', session);
+
+  await bridge.sessionPicker.handleSessionPickerCallback({
+    type: 'callback',
+    callbackQueryId: 'callback-1',
+    data: 'sess_token',
+    chatId: 'chat-1',
+  });
+
+  assert.equal(bridge.provider, 'codex');
+  assert.equal(data.provider, 'codex');
+  assert.equal(data.codexLastSessionId, 'codex-session');
+  assert.equal(bridge.selectedSessionCwd, '/Users/geert/code/selected');
+  assert.equal(bridge.forceNewNextPrompt, false);
+  assert.deepEqual(answeredCallbacks, [{ callbackQueryId: 'callback-1', text: 'Codex geselecteerd' }]);
+  assert.equal(sentMessages[0].chatId, 'chat-1');
+  assert.match(sentMessages[0].text, /Selected Codex session/);
+});
+
+test('handleSessionPickerCallback stops active prompt and clears queued messages before switching', async () => {
+  const data = {
+    provider: 'claude',
+    claudeArgs: [],
+    codexArgs: [],
+    claudeLastSessionId: 'old-claude-session',
+    codexLastSessionId: null,
+    telegramChatId: 'chat-1',
+  };
+  const config = {
+    get claudeArgs() {
+      return data.claudeArgs;
+    },
+    get codexArgs() {
+      return data.codexArgs;
+    },
+    get claudeLastSessionId() {
+      return data.claudeLastSessionId;
+    },
+    get codexLastSessionId() {
+      return data.codexLastSessionId;
+    },
+    get telegramChatId() {
+      return data.telegramChatId;
+    },
+    get telegramBotUsername() {
+      return null;
+    },
+    set(key, value) {
+      data[key] = value;
+    },
+    setMany(updates) {
+      Object.assign(data, updates);
+    },
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  bridge.logCliEvent = () => {};
+  bridge.telegram = {
+    sendMessage() {},
+    answerCallbackQuery() {},
+  };
+  const abortController = new globalThis.AbortController();
+  bridge.activePromptAbortController = abortController;
+  bridge.telegramPendingMessages = ['queued for old session'];
+  bridge.sessionPicker.sessionPickerEntries.set(
+    'sess_token',
+    makeSession(1, {
+      agentType: 'codex',
+      id: 'codex-session',
+      cwd: '/Users/geert/code/selected',
+    })
+  );
+
+  await bridge.sessionPicker.handleSessionPickerCallback({
+    type: 'callback',
+    callbackQueryId: 'callback-1',
+    data: 'sess_token',
+    chatId: 'chat-1',
+  });
+
+  assert.equal(abortController.signal.aborted, true);
+  assert.equal(bridge.activePromptAbortReason, 'session_switch');
+  assert.deepEqual(bridge.telegramPendingMessages, []);
+  assert.equal(bridge.provider, 'codex');
+  assert.equal(data.codexLastSessionId, 'codex-session');
+});
+
+test('handleSessionProjectCallback shows new-session buttons and existing sessions for a project', async () => {
+  const data = {
+    provider: 'claude',
+    claudeArgs: [],
+    codexArgs: [],
+    claudeLastSessionId: null,
+    codexLastSessionId: null,
+    telegramChatId: 'chat-1',
+  };
+  const sentMessages = [];
+  const answeredCallbacks = [];
+  const config = {
+    get claudeArgs() {
+      return data.claudeArgs;
+    },
+    get codexArgs() {
+      return data.codexArgs;
+    },
+    get claudeLastSessionId() {
+      return data.claudeLastSessionId;
+    },
+    get codexLastSessionId() {
+      return data.codexLastSessionId;
+    },
+    get telegramChatId() {
+      return data.telegramChatId;
+    },
+    get telegramBotUsername() {
+      return null;
+    },
+    set(key, value) {
+      data[key] = value;
+    },
+    setMany(updates) {
+      Object.assign(data, updates);
+    },
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  bridge.logCliEvent = () => {};
+  bridge.telegram = {
+    sendMessage(chatId, text, options) {
+      sentMessages.push({ chatId, text, options });
+    },
+    answerCallbackQuery(callbackQueryId, text) {
+      answeredCallbacks.push({ callbackQueryId, text });
+    },
+  };
+  bridge.sessionPicker.sessionPickerProjectEntries.set('proj_alpha', {
+    project: 'alpha',
+    cwd: '/tmp/alpha',
+    sessions: [
+      makeSession(1, { id: 'alpha-claude', project: 'alpha', cwd: '/tmp/alpha', agentType: 'claude', title: 'Claude alpha work' }),
+      makeSession(2, { id: 'alpha-codex', project: 'alpha', cwd: '/tmp/alpha', agentType: 'codex', title: 'Codex alpha work' }),
+    ],
+  });
+
+  await bridge.sessionPicker.handleSessionProjectCallback({
+    type: 'callback',
+    callbackQueryId: 'callback-1',
+    data: 'proj_alpha',
+    chatId: 'chat-1',
+  });
+
+  assert.deepEqual(answeredCallbacks, [{ callbackQueryId: 'callback-1', text: 'alpha' }]);
+  assert.equal(sentMessages[0].chatId, 'chat-1');
+  assert.match(sentMessages[0].text, /Kies een sessie voor alpha/);
+  assert.deepEqual(
+    sentMessages[0].options.replyMarkup.inline_keyboard[0].map(button => button.text),
+    ['New Claude', 'New Codex']
+  );
+  assert.equal(sentMessages[0].options.replyMarkup.inline_keyboard.length, 3);
+  assert.equal(new Set([...bridge.sessionPicker.sessionPickerEntries.values()].map(session => session.id)).size, 2);
+  assert.deepEqual(
+    [...bridge.sessionPicker.newSessionProjectEntries.values()].map(entry => entry.provider),
+    ['claude', 'codex']
+  );
+});
+
+test('handleSessionProjectCallback does not auto-select single-session projects', async () => {
+  const data = {
+    provider: 'claude',
+    claudeArgs: [],
+    codexArgs: [],
+    claudeLastSessionId: null,
+    codexLastSessionId: null,
+    telegramChatId: 'chat-1',
+  };
+  const sentMessages = [];
+  const config = {
+    get claudeArgs() {
+      return data.claudeArgs;
+    },
+    get codexArgs() {
+      return data.codexArgs;
+    },
+    get claudeLastSessionId() {
+      return data.claudeLastSessionId;
+    },
+    get codexLastSessionId() {
+      return data.codexLastSessionId;
+    },
+    get telegramChatId() {
+      return data.telegramChatId;
+    },
+    get telegramBotUsername() {
+      return null;
+    },
+    set(key, value) {
+      data[key] = value;
+    },
+    setMany(updates) {
+      Object.assign(data, updates);
+    },
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  bridge.logCliEvent = () => {};
+  bridge.telegram = {
+    sendMessage(chatId, text, options) {
+      sentMessages.push({ chatId, text, options });
+    },
+    answerCallbackQuery() {},
+  };
+  bridge.sessionPicker.sessionPickerProjectEntries.set('proj_beta', {
+    project: 'beta',
+    cwd: '/tmp/beta',
+    sessions: [makeSession(1, { id: 'beta-codex', project: 'beta', cwd: '/tmp/beta', agentType: 'codex', title: 'Codex beta work' })],
+  });
+
+  await bridge.sessionPicker.handleSessionProjectCallback({
+    type: 'callback',
+    callbackQueryId: 'callback-1',
+    data: 'proj_beta',
+    chatId: 'chat-1',
+  });
+
+  assert.match(sentMessages[0].text, /Kies een sessie voor beta/);
+  assert.deepEqual(
+    sentMessages[0].options.replyMarkup.inline_keyboard[0].map(button => button.text),
+    ['New Codex']
+  );
+  assert.equal(data.codexLastSessionId, null);
+  assert.equal(bridge.forceNewNextPrompt, false);
+});
+
+test('handleNewSessionCallback selects provider, project cwd and fresh session mode', async () => {
+  const data = {
+    provider: 'codex',
+    claudeArgs: [],
+    codexArgs: [],
+    claudeLastSessionId: 'old-claude-session',
+    codexLastSessionId: 'old-codex-session',
+    telegramChatId: 'chat-1',
+  };
+  const sentMessages = [];
+  const answeredCallbacks = [];
+  const config = {
+    get claudeArgs() {
+      return data.claudeArgs;
+    },
+    get codexArgs() {
+      return data.codexArgs;
+    },
+    get claudeLastSessionId() {
+      return data.claudeLastSessionId;
+    },
+    get codexLastSessionId() {
+      return data.codexLastSessionId;
+    },
+    get telegramChatId() {
+      return data.telegramChatId;
+    },
+    get telegramBotUsername() {
+      return null;
+    },
+    set(key, value) {
+      data[key] = value;
+    },
+    setMany(updates) {
+      Object.assign(data, updates);
+    },
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'codex', []);
+  bridge.logCliEvent = () => {};
+  bridge.telegram = {
+    sendMessage(chatId, text) {
+      sentMessages.push({ chatId, text });
+    },
+    answerCallbackQuery(callbackQueryId, text) {
+      answeredCallbacks.push({ callbackQueryId, text });
+    },
+  };
+  const abortController = new globalThis.AbortController();
+  bridge.activePromptAbortController = abortController;
+  bridge.telegramPendingMessages = ['queued for old session'];
+  bridge.sessionPicker.newSessionProjectEntries.set('new_alpha_claude', {
+    provider: 'claude',
+    project: 'alpha',
+    cwd: '/tmp/alpha',
+  });
+
+  await bridge.sessionPicker.handleNewSessionCallback({
+    type: 'callback',
+    callbackQueryId: 'callback-1',
+    data: 'new_alpha_claude',
+    chatId: 'chat-1',
+  });
+
+  assert.equal(abortController.signal.aborted, true);
+  assert.equal(bridge.activePromptAbortReason, 'session_switch');
+  assert.deepEqual(bridge.telegramPendingMessages, []);
+  assert.equal(bridge.provider, 'claude');
+  assert.equal(data.provider, 'claude');
+  assert.equal(data.claudeLastSessionId, null);
+  assert.equal(data.codexLastSessionId, 'old-codex-session');
+  assert.equal(bridge.selectedSessionCwd, '/tmp/alpha');
+  assert.equal(bridge.forceNewNextPrompt, true);
+  assert.deepEqual(answeredCallbacks, [{ callbackQueryId: 'callback-1', text: 'New Claude' }]);
+  assert.match(sentMessages[0].text, /New Claude session selected/);
+});
+
+test('handleCommand accepts bot-suffixed sessions command from Telegram menu', async () => {
+  const config = {
+    get claudeArgs() {
+      return [];
+    },
+    get codexArgs() {
+      return [];
+    },
+    get claudeLastSessionId() {
+      return null;
+    },
+    get codexLastSessionId() {
+      return null;
+    },
+    get telegramChatId() {
+      return 'chat-1';
+    },
+    get telegramBotUsername() {
+      return 'RegelneefBot';
+    },
+    set() {},
+    setMany() {},
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  let showSessionPickerCalls = 0;
+  bridge.sessionPicker.showSessionPicker = async () => {
+    showSessionPickerCalls += 1;
+  };
+  bridge.safeSendMessage = async () => {
+    throw new Error('Expected /sessions command to open picker');
+  };
+
+  await bridge.handleCommand('/sessions@RegelneefBot');
+
+  assert.equal(showSessionPickerCalls, 1);
+});
+
+test('configureTelegramCommands registers one short session menu command for the paired chat', async () => {
+  const config = {
+    get claudeArgs() {
+      return [];
+    },
+    get codexArgs() {
+      return [];
+    },
+    get claudeLastSessionId() {
+      return null;
+    },
+    get codexLastSessionId() {
+      return null;
+    },
+    get telegramChatId() {
+      return '6314031751';
+    },
+    get telegramBotUsername() {
+      return 'RegelneefBot';
+    },
+    set() {},
+    setMany() {},
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', [], {
+    gatherSessions: async () => [makeSession(1, { agentType: 'claude' }), makeSession(2, { agentType: 'codex' })],
+  });
+  const calls = [];
+
+  await bridge.sessionPicker.configureTelegramCommands({
+    async setCommands(commands, options) {
+      calls.push({ commands, options });
+    },
+  });
+
+  assert.deepEqual(
+    calls[0].commands.map(command => command.command),
+    ['help', 'new', 'stop', 'claude', 'codex', 'projects', 'sessions', 'status']
+  );
+  assert.equal(calls[0].commands.find(command => command.command === 'sessions')?.description, 'Choose session');
+  assert.equal(calls[0].commands.find(command => command.command === 'projects')?.description, 'Choose project');
+  assert.deepEqual(calls[0].options, { chatId: '6314031751' });
+});
+
+test('handleLocalInputLine opens the session picker for /sessions', async () => {
+  const config = {
+    get claudeArgs() {
+      return [];
+    },
+    get codexArgs() {
+      return [];
+    },
+    get claudeLastSessionId() {
+      return null;
+    },
+    get codexLastSessionId() {
+      return null;
+    },
+    get telegramChatId() {
+      return 'chat-1';
+    },
+    get telegramBotUsername() {
+      return 'RegelneefBot';
+    },
+    set() {},
+    setMany() {},
+    clearPairing() {},
+  };
+  const bridge = new Bridge(config, 'claude', []);
+  bridge.running = true;
+  let showSessionPickerCalls = 0;
+  bridge.sessionPicker.showSessionPicker = async () => {
+    showSessionPickerCalls += 1;
+  };
+  bridge.writeCliLine = message => {
+    throw new Error(`Expected /sessions local command to open picker, got: ${message}`);
+  };
+
+  await bridge.handleLocalInputLine('/sessions');
+
+  assert.equal(showSessionPickerCalls, 1);
+});

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, utimes } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { gatherSessions, parseClaudeSessionFile, parseCodexSessionFile } from '../src/sessions.js';
+
+async function makeHome() {
+  return mkdtemp(path.join(os.tmpdir(), 'heyagent-sessions-'));
+}
+
+async function writeJsonl(filePath, entries) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, entries.map(entry => (typeof entry === 'string' ? entry : JSON.stringify(entry))).join('\n'));
+}
+
+test('gatherSessions combines Claude and Codex sessions sorted newest first', async () => {
+  const homeDir = await makeHome();
+  const claudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-alpha', 'claude-1.jsonl');
+  const codexFile = path.join(homeDir, '.codex', 'sessions', '2026', '05', '29', 'codex-1.jsonl');
+
+  await writeJsonl(claudeFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T08:00:00.000Z',
+      message: { content: [{ type: 'text', text: 'start Claude work' }] },
+    },
+    {
+      type: 'assistant',
+      message: { model: 'claude-sonnet-4-20250514' },
+    },
+  ]);
+  await writeJsonl(codexFile, [
+    {
+      type: 'session_meta',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      payload: {
+        id: 'codex-1',
+        cwd: '/Users/geert/code/beta',
+        timestamp: '2026-05-29T09:00:00.000Z',
+      },
+    },
+    {
+      type: 'response_item',
+      timestamp: '2026-05-29T10:00:00.000Z',
+      payload: {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'continue Codex work' }],
+      },
+    },
+  ]);
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 3650 });
+
+  assert.equal(sessions.length, 2);
+  assert.equal(sessions[0].id, 'codex-1');
+  assert.equal(sessions[0].agentType, 'codex');
+  assert.equal(sessions[0].project, 'beta');
+  assert.equal(sessions[1].id, 'claude-1');
+  assert.equal(sessions[1].agentType, 'claude');
+  assert.equal(sessions[1].project, 'alpha');
+});
+
+test('parseClaudeSessionFile ignores corrupt lines and returns last user message', async () => {
+  const homeDir = await makeHome();
+  const filePath = path.join(homeDir, 'claude.jsonl');
+  await writeJsonl(filePath, [
+    '{not-json',
+    {
+      type: 'user',
+      timestamp: '2026-05-29T08:00:00.000Z',
+      message: { content: [{ type: 'text', text: 'first question' }] },
+    },
+    {
+      type: 'user',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      message: { content: [{ type: 'text', text: 'latest question' }] },
+    },
+  ]);
+
+  const session = parseClaudeSessionFile(filePath, 'claude-session', '-Users-geert-code-myproject');
+
+  assert.equal(session.id, 'claude-session');
+  assert.equal(session.title, 'first question');
+  assert.equal(session.lastUserMessage, 'latest question');
+  assert.equal(session.lastUserMessageAt, '2026-05-29T09:00:00.000Z');
+  assert.equal(session.cwd, '/Users/geert/code/myproject');
+});
+
+test('gatherSessions uses Codex thread names from session index', async () => {
+  const homeDir = await makeHome();
+  const codexFile = path.join(homeDir, '.codex', 'sessions', '2026', '05', '29', 'codex-title.jsonl');
+  const indexFile = path.join(homeDir, '.codex', 'session_index.jsonl');
+
+  await writeJsonl(codexFile, [
+    {
+      type: 'session_meta',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      payload: {
+        id: 'codex-title',
+        cwd: '/Users/geert/code/heyagent',
+      },
+    },
+    {
+      type: 'response_item',
+      timestamp: '2026-05-29T10:00:00.000Z',
+      payload: {
+        role: 'user',
+        content: [{ type: 'input_text', text: '# AGENTS.md instructions for /Users/geert/code/heyagent' }],
+      },
+    },
+  ]);
+  await writeJsonl(indexFile, [
+    {
+      id: 'codex-title',
+      thread_name: 'Voeg sessiekeuze toe',
+      updated_at: '2026-05-29T10:00:00.000Z',
+    },
+  ]);
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 3650 });
+
+  assert.equal(sessions[0].id, 'codex-title');
+  assert.equal(sessions[0].title, 'Voeg sessiekeuze toe');
+});
+
+test('gatherSessions uses Claude Desktop local session titles', async () => {
+  const homeDir = await makeHome();
+  const claudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-title.jsonl');
+  const localSessionFile = path.join(
+    homeDir,
+    'Library',
+    'Application Support',
+    'Claude',
+    'claude-code-sessions',
+    'workspace',
+    'project',
+    'local-session.json'
+  );
+
+  await writeJsonl(claudeFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T08:00:00.000Z',
+      message: { content: 'pull' },
+    },
+  ]);
+  await mkdir(path.dirname(localSessionFile), { recursive: true });
+  await writeFile(
+    localSessionFile,
+    JSON.stringify({
+      sessionId: 'local-1',
+      cliSessionId: 'claude-title',
+      title: 'Telegram plugin installation',
+    })
+  );
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 3650 });
+
+  assert.equal(sessions[0].id, 'claude-title');
+  assert.equal(sessions[0].title, 'Telegram plugin installation');
+});
+
+test('parseCodexSessionFile skips sessions without a user message', async () => {
+  const homeDir = await makeHome();
+  const filePath = path.join(homeDir, 'codex.jsonl');
+  await writeJsonl(filePath, [
+    {
+      type: 'session_meta',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      payload: { id: 'codex-empty', cwd: '/Users/geert/code/empty' },
+    },
+  ]);
+
+  assert.equal(parseCodexSessionFile(filePath), null);
+});
+
+test('gatherSessions skips files older than maxAgeDays', async () => {
+  const homeDir = await makeHome();
+  const oldFile = path.join(homeDir, '.codex', 'sessions', '2026', '05', '29', 'old.jsonl');
+  await writeJsonl(oldFile, [
+    {
+      type: 'session_meta',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      payload: { id: 'old-session', cwd: '/Users/geert/code/old' },
+    },
+    {
+      type: 'response_item',
+      timestamp: '2026-05-29T10:00:00.000Z',
+      payload: { role: 'user', content: [{ type: 'input_text', text: 'old prompt' }] },
+    },
+  ]);
+  await utimes(oldFile, new Date('2020-01-01T00:00:00.000Z'), new Date('2020-01-01T00:00:00.000Z'));
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 1 });
+
+  assert.deepEqual(sessions, []);
+});

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -14,6 +14,11 @@ async function writeJsonl(filePath, entries) {
   await writeFile(filePath, entries.map(entry => (typeof entry === 'string' ? entry : JSON.stringify(entry))).join('\n'));
 }
 
+async function writeJsonFile(filePath, entry) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(entry));
+}
+
 test('gatherSessions combines Claude and Codex sessions sorted newest first', async () => {
   const homeDir = await makeHome();
   const claudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-alpha', 'claude-1.jsonl');
@@ -159,6 +164,124 @@ test('gatherSessions uses Claude Desktop local session titles', async () => {
 
   assert.equal(sessions[0].id, 'claude-title');
   assert.equal(sessions[0].title, 'Telegram plugin installation');
+});
+
+test('gatherSessions skips Claude sessions marked archived in Claude Desktop metadata', async () => {
+  const homeDir = await makeHome();
+  const activeClaudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-active.jsonl');
+  const archivedClaudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-archived.jsonl');
+  const metadataDir = path.join(homeDir, 'Library', 'Application Support', 'Claude', 'claude-code-sessions', 'workspace', 'project');
+
+  await writeJsonl(activeClaudeFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T08:00:00.000Z',
+      message: { content: 'active session prompt' },
+    },
+  ]);
+  await writeJsonl(archivedClaudeFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      message: { content: 'archived session prompt' },
+    },
+  ]);
+  await writeJsonFile(path.join(metadataDir, 'active.json'), {
+    cliSessionId: 'claude-active',
+    title: 'Active Claude session',
+    isArchived: false,
+  });
+  await writeJsonFile(path.join(metadataDir, 'archived.json'), {
+    cliSessionId: 'claude-archived',
+    title: 'Archived Claude session',
+    isArchived: true,
+  });
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 3650 });
+
+  assert.deepEqual(
+    sessions.map(session => session.id),
+    ['claude-active']
+  );
+  assert.equal(sessions[0].title, 'Active Claude session');
+});
+
+test('gatherSessions treats duplicate Claude metadata as archived when any entry is archived', async () => {
+  const homeDir = await makeHome();
+  const claudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-duplicate.jsonl');
+  const metadataDir = path.join(homeDir, 'Library', 'Application Support', 'Claude', 'claude-code-sessions', 'workspace', 'project');
+
+  await writeJsonl(claudeFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T08:00:00.000Z',
+      message: { content: 'duplicate metadata prompt' },
+    },
+  ]);
+  await writeJsonFile(path.join(metadataDir, 'duplicate-active.json'), {
+    cliSessionId: 'claude-duplicate',
+    title: 'Duplicate active metadata',
+    isArchived: false,
+  });
+  await writeJsonFile(path.join(metadataDir, 'duplicate-archived.json'), {
+    cliSessionId: 'claude-duplicate',
+    isArchived: true,
+  });
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 3650 });
+
+  assert.deepEqual(sessions, []);
+});
+
+test('gatherSessions skips Claude sessions with alternative archive markers', async () => {
+  const homeDir = await makeHome();
+  const activeClaudeFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-visible.jsonl');
+  const archivedFlagFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-archived-flag.jsonl');
+  const archivedStatusFile = path.join(homeDir, '.claude', 'projects', '-Users-geert-code-bvgeert', 'claude-archived-status.jsonl');
+  const metadataDir = path.join(homeDir, 'Library', 'Application Support', 'Claude', 'claude-code-sessions', 'workspace', 'project');
+
+  await writeJsonl(activeClaudeFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T08:00:00.000Z',
+      message: { content: 'visible session prompt' },
+    },
+  ]);
+  await writeJsonl(archivedFlagFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T09:00:00.000Z',
+      message: { content: 'archived flag prompt' },
+    },
+  ]);
+  await writeJsonl(archivedStatusFile, [
+    {
+      type: 'user',
+      timestamp: '2026-05-29T10:00:00.000Z',
+      message: { content: 'archived status prompt' },
+    },
+  ]);
+  await writeJsonFile(path.join(metadataDir, 'active.json'), {
+    cliSessionId: 'claude-visible',
+    title: 'Visible Claude session',
+    isArchived: false,
+  });
+  await writeJsonFile(path.join(metadataDir, 'archived-flag.json'), {
+    cliSessionId: 'claude-archived-flag',
+    archived: true,
+  });
+  await writeJsonFile(path.join(metadataDir, 'archived-status.json'), {
+    cliSessionId: 'claude-archived-status',
+    status: 'archived',
+  });
+
+  const sessions = await gatherSessions({ homeDir, maxAgeDays: 3650 });
+
+  assert.deepEqual(
+    sessions.map(session => session.id),
+    ['claude-visible']
+  );
+  assert.equal(sessions[0].title, 'Visible Claude session');
 });
 
 test('parseCodexSessionFile skips sessions without a user message', async () => {

--- a/test/telegram-api.test.js
+++ b/test/telegram-api.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { TelegramApi, buildSendMessageOptions, normalizeCallback, normalizeMessage } from '../src/telegram-api.js';
+
+test('normalizeMessage keeps text message behavior', () => {
+  const message = normalizeMessage({
+    update_id: 10,
+    message: {
+      message_id: 20,
+      text: '  /sessions  ',
+      chat: { id: 30, type: 'private' },
+      from: { id: 40 },
+    },
+  });
+
+  assert.deepEqual(message, {
+    updateId: 10,
+    messageId: 20,
+    chatId: '30',
+    chatType: 'private',
+    userId: '40',
+    type: 'text',
+    text: '/sessions',
+    caption: '',
+    fileId: null,
+    fileName: null,
+    mimeType: null,
+    fileSizeBytes: null,
+    durationSec: null,
+  });
+});
+
+test('normalizeCallback returns callback query details', () => {
+  const callback = normalizeCallback({
+    update_id: 11,
+    callback_query: {
+      id: 'callback-1',
+      data: 'sess_123',
+      from: { id: 41 },
+      message: {
+        message_id: 21,
+        chat: { id: 31, type: 'private' },
+      },
+    },
+  });
+
+  assert.deepEqual(callback, {
+    updateId: 11,
+    type: 'callback',
+    callbackQueryId: 'callback-1',
+    data: 'sess_123',
+    chatId: '31',
+    chatType: 'private',
+    userId: '41',
+    messageId: 21,
+  });
+});
+
+test('normalizeCallback ignores callbacks without data', () => {
+  assert.equal(
+    normalizeCallback({
+      update_id: 12,
+      callback_query: {
+        id: 'callback-2',
+        from: { id: 42 },
+      },
+    }),
+    null
+  );
+});
+
+test('buildSendMessageOptions includes inline keyboard reply markup', () => {
+  const replyMarkup = {
+    inline_keyboard: [[{ text: 'Claude | project | 1m | title', callback_data: 'sess_1' }]],
+  };
+
+  assert.deepEqual(buildSendMessageOptions({ replyMarkup }), {
+    reply_markup: replyMarkup,
+  });
+});
+
+test('buildSendMessageOptions returns empty object without options', () => {
+  assert.deepEqual(buildSendMessageOptions(), {});
+});
+
+test('setCommands forwards bot commands to the default scope when unpaired', async () => {
+  const calls = [];
+  const api = Object.create(TelegramApi.prototype);
+  api.bot = {
+    async setMyCommands(commands, options) {
+      calls.push({ commands, options });
+    },
+  };
+  const commands = [
+    { command: 'sessions', description: 'Choose a recent Claude or Codex session' },
+    { command: 'status', description: 'Show current status' },
+  ];
+
+  await api.setCommands(commands);
+
+  assert.deepEqual(calls, [{ commands, options: undefined }]);
+});
+
+test('setCommands scopes bot commands to the paired chat only', async () => {
+  const calls = [];
+  const api = Object.create(TelegramApi.prototype);
+  api.bot = {
+    async setMyCommands(commands, options) {
+      calls.push({ commands, options });
+    },
+  };
+  const commands = [
+    { command: 'sessions', description: 'Choose a recent Claude or Codex session' },
+    { command: 'status', description: 'Show current status' },
+  ];
+
+  await api.setCommands(commands, { chatId: '6314031751' });
+
+  assert.deepEqual(calls, [{ commands, options: { scope: { type: 'chat', chat_id: 6314031751 } } }]);
+});


### PR DESCRIPTION
## Summary
- Add `/sessions` to choose one of the 10 most recent local Claude or Codex sessions from Telegram or the local CLI.
- Add `/projects` to pick a project first, then continue an existing session or start a new Claude/Codex session for that project.
- Add inline-keyboard callback handling, scoped Telegram bot commands, and callback reply-markup support.
- Discover local Claude and Codex session metadata, including Codex thread names and Claude Desktop titles, while hiding archived Claude sessions.

## Review notes
- The picker logic is isolated in `src/session-picker.js` to keep `src/bridge.js` reviewable.
- The PR intentionally does not change `.github/workflows/npm-publish.yml`.
- The Dutch `/sessies` alias was removed; only `/sessions` is documented and handled.

## Validation
- `npm run lint`
- `npx prettier --check README.md package.json src/bridge.js src/session-picker.js src/sessions.js src/telegram-api.js test/session-picker.test.js test/sessions.test.js test/telegram-api.test.js`
- `npm test`

The PR remains a draft.